### PR TITLE
Fixed stack trace error when no arguments are passed

### DIFF
--- a/apk2java.py
+++ b/apk2java.py
@@ -20,7 +20,7 @@ project_name = ''
 sign_file = ''
 cwd = os.path.dirname(os.path.abspath(__file__))
 home = os.path.dirname(os.path.realpath(sys.argv[0]))
-outdir = os.path.dirname(os.path.realpath(sys.argv[1]))
+outdir = None
 external = "https://github.com/TheZ3ro/apk2java-linux/releases/download/tool/tool.zip"
 
 


### PR DESCRIPTION
The application throws stack trace when you run it without any argument. It is caused by the variable association (probably some old, uncleaned stuff) which is overwrote after arguments are parsed by argparse.